### PR TITLE
adding guards for unnecessary computations and adjusting jitter backoff type

### DIFF
--- a/examples/example01/example01.go
+++ b/examples/example01/example01.go
@@ -15,7 +15,7 @@ func faultyTCPGenerator() func(string, string, string) (net.Listener, error) {
 	return func(protocol, address, port string) (net.Listener, error) {
 		if failedAttempts > 0 {
 			failedAttempts--
-			return nil, fmt.Errorf("Haha!") // :)
+			return nil, fmt.Errorf("haha") // :)
 		}
 		l, err := net.Listen(protocol, fmt.Sprintf("%s:%s", address, port))
 		return l, err

--- a/goback.go
+++ b/goback.go
@@ -47,8 +47,9 @@ type Backoff interface {
 
 // SimpleBackoff provides a simple strategy to backoff.
 type SimpleBackoff struct {
-	Attempts    int
-	MaxAttempts int
+	attempts    uint64
+	next        time.Duration
+	MaxAttempts uint64
 	Factor      float64
 	Min         time.Duration
 	Max         time.Duration
@@ -56,42 +57,59 @@ type SimpleBackoff struct {
 
 // NextAttempt returns the duration to wait for the next retry.
 func (b *SimpleBackoff) NextAttempt() (time.Duration, error) {
-	if b.MaxAttempts > 0 && b.Attempts >= b.MaxAttempts {
+	if b.MaxAttempts > 0 && b.attempts >= b.MaxAttempts {
 		return 0, ErrMaxAttemptsExceeded
 	}
-	next := GetNextDuration(b.Min, b.Max, b.Factor, b.Attempts)
-	b.Attempts++
-	return next, nil
+
+	switch {
+	case b.next >= b.Max:
+		b.next = b.Max
+	default:
+		b.next = GetNextDuration(b.Min, b.Max, b.Factor, b.attempts)
+	}
+
+	// We should guard against overflow in cases where MaxAttempts is not set
+	if b.attempts < math.MaxUint64 {
+		b.attempts++
+	}
+
+	return b.next, nil
 }
 
 // Reset clears the number of tries. Next call to NextAttempt will return
 // the minimum backoff time (if there is no error).
 func (b *SimpleBackoff) Reset() {
-	b.Attempts = 0
+	b.attempts = 0
+	b.next = 0
 }
 
 // JitterBackoff provides an strategy similar to SimpleBackoff but lightly randomises
 // the duration to minimise collisions between contending clients.
-type JitterBackoff SimpleBackoff
+type JitterBackoff struct {
+	SimpleBackoff
+}
 
 // NextAttempt returns the duration to wait for the next retry.
 func (b *JitterBackoff) NextAttempt() (time.Duration, error) {
-	if b.MaxAttempts > 0 && b.Attempts >= b.MaxAttempts {
-		return 0, ErrMaxAttemptsExceeded
+	next, err := b.SimpleBackoff.NextAttempt()
+	if err != nil {
+		return 0, err
 	}
-	next := GetNextDuration(b.Min, b.Max, b.Factor, b.Attempts)
-	next = addJitter(next, b.Min)
-	b.Attempts++
-	return next, nil
+
+	return addJitter(next, b.Min), nil
 }
+
+
 
 // GetNextDuration returns the duration for the strategies considering the minimum and
 // maximum durations, the factor of increase and the number of attemtps tried.
-func GetNextDuration(min, max time.Duration, factor float64, attempts int) time.Duration {
+func GetNextDuration(min, max time.Duration, factor float64, attempts uint64) time.Duration {
 	d := time.Duration(float64(min) * math.Pow(factor, float64(attempts)))
+
 	if d > max {
 		return max
 	}
+
 	return d
 }
 
@@ -101,7 +119,9 @@ func Wait(b Backoff) error {
 	if err != nil {
 		return err
 	}
+
 	time.Sleep(next)
+
 	return nil
 }
 
@@ -109,15 +129,21 @@ func Wait(b Backoff) error {
 // strategy or will exit immediately with an error.
 func After(b Backoff) <-chan error {
 	c := make(chan error, 1)
+
 	next, err := b.NextAttempt()
 	if err != nil {
 		c <- err
+		close(c)
+
 		return c
 	}
+
 	go func() {
 		time.Sleep(next)
 		c <- nil
+		close(c)
 	}()
+
 	return c
 }
 

--- a/goback_test.go
+++ b/goback_test.go
@@ -2,116 +2,361 @@ package goback
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	defaultFactor   = 2.0
+	defaultAttempts = uint64(3)
+	defaultMinimum  = 100 * time.Millisecond
+	defaultMaximum  = time.Duration(float64(defaultMinimum) * math.Pow(defaultFactor, float64(defaultAttempts)))
+)
+
 func TestAfter(t *testing.T) {
 	b := &SimpleBackoff{
-		Factor:      2,
-		Min:         100 * time.Millisecond,
+		Factor:      defaultFactor,
+		Min:         defaultMinimum,
 		Max:         2 * time.Second,
 		MaxAttempts: 1,
 	}
-	var t1, t2, t3 time.Time
-	var err1, err2 error
-	t1 = time.Now()
-	select {
-	case err1 = <-After(b):
-		t2 = time.Now()
-	case <-time.After(101 * time.Millisecond):
-		t.Error("Not executed on time")
-	}
-	select {
-	case err2 = <-After(b):
-	case <-time.After(time.Millisecond):
-		t.Error("Not executed on time")
-	}
-	t3 = time.Now()
-	assert.WithinDuration(t, t1.Add(100*time.Millisecond), t2, time.Millisecond)
-	assert.WithinDuration(t, t2, t3, time.Millisecond)
+	err1 := <-After(b)
+	err2 := <-After(b)
+
 	assert.Nil(t, err1)
 	assert.NotNil(t, err2)
-
 }
 
 func TestWait(t *testing.T) {
 	b := &SimpleBackoff{
-		Factor:      2,
-		Min:         100 * time.Millisecond,
+		Factor:      defaultFactor,
+		Min:         defaultMinimum,
 		Max:         2 * time.Second,
 		MaxAttempts: 1,
 	}
-	t1 := time.Now()
 	err1 := Wait(b)
-	t2 := time.Now()
 	err2 := Wait(b)
-	t3 := time.Now()
-	assert.WithinDuration(t, t1.Add(100*time.Millisecond), t2, time.Millisecond)
-	assert.WithinDuration(t, t2, t3, time.Millisecond)
+
 	assert.Nil(t, err1)
 	assert.NotNil(t, err2)
-
-}
-
-func TestSimple(t *testing.T) {
-	b := &SimpleBackoff{
-		Factor:      2,
-		Min:         100 * time.Millisecond,
-		Max:         2 * time.Second,
-		MaxAttempts: 6,
-	}
-	next, err := b.NextAttempt()
-	assert.Equal(t, 100*time.Millisecond, next)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	assert.Equal(t, 200*time.Millisecond, next)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	assert.Equal(t, 400*time.Millisecond, next)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	assert.Equal(t, 800*time.Millisecond, next)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	assert.Equal(t, 1600*time.Millisecond, next)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	assert.Equal(t, 2*time.Second, next)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	assert.NotNil(t, err)
-	b.Reset()
-	next, err = b.NextAttempt()
-	assert.Equal(t, 100*time.Millisecond, next)
-	assert.Nil(t, err)
-}
-
-func TestJitter(t *testing.T) {
-	min := 100 * time.Millisecond
-	b := &JitterBackoff{
-		Factor:      2,
-		Min:         min,
-		Max:         10 * time.Second,
-		MaxAttempts: 3,
-	}
-	next, err := b.NextAttempt()
-	between(t, next, 100*time.Millisecond, min)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	between(t, next, 200*time.Millisecond, min)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	between(t, next, 400*time.Millisecond, min)
-	assert.Nil(t, err)
-	next, err = b.NextAttempt()
-	assert.NotNil(t, err)
 }
 
 func between(t *testing.T, next, expected, offset time.Duration) {
 	assert.True(t, next >= expected-offset, fmt.Sprintf("%v %v %v", next, expected, offset))
 	assert.True(t, next <= expected+offset, fmt.Sprintf("%v %v %v", next, expected, offset))
+}
 
+func TestGetNextDuration(t *testing.T) {
+	type args struct {
+		min      time.Duration
+		max      time.Duration
+		factor   float64
+		attempts uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Duration
+	}{
+		{
+			name: "ensure that if given a max that is greater than min^(factor*attempts), then min^(factor*attempts) is returned",
+			args: args{
+				min:      defaultMinimum,
+				max:      defaultMaximum,
+				factor:   defaultFactor,
+				attempts: 0,
+			},
+			want: defaultMinimum,
+		},
+		{
+			name: "ensure that if given a max that is equal to min^(factor*attempts), then max is returned",
+			args: args{
+				min:      defaultMinimum,
+				max:      defaultMaximum,
+				factor:   defaultFactor,
+				attempts: defaultAttempts,
+			},
+			want: defaultMaximum,
+		},
+		{
+			name: "ensure that if given a max that is less than min^(factor*attempts), then max is returned",
+			args: args{
+				min:      defaultMinimum,
+				max:      defaultMaximum,
+				factor:   defaultFactor,
+				attempts: defaultAttempts + 1,
+			},
+			want: defaultMaximum,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetNextDuration(tt.args.min, tt.args.max, tt.args.factor, tt.args.attempts)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSimpleBackoff_NextAttempt(t *testing.T) {
+	type fields struct {
+		attempts    uint64
+		next        time.Duration
+		MaxAttempts uint64
+		Factor      float64
+		Min         time.Duration
+		Max         time.Duration
+	}
+	type want struct {
+		result   time.Duration
+		next     time.Duration
+		attempts uint64
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    want
+		wantErr bool
+	}{
+		{
+			name: "ensure that if MaxAttempts is zero, next is less than Max, and attempts is less than math.MaxUint64, then a positive time.Duration and no error is returned",
+			fields: fields{
+				attempts:    0,
+				next:        0,
+				MaxAttempts: 0,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMinimum,
+				next:     defaultMinimum,
+				attempts: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is zero, next is equal to Max, and attempts is less than math.MaxUint64, then the Max and no error is returned",
+			fields: fields{
+				attempts:    0,
+				next:        defaultMaximum,
+				MaxAttempts: 0,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMaximum,
+				next:     defaultMaximum,
+				attempts: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is zero, next is greater than Max, and attempts is less than math.MaxUint64, then the Max and no error is returned",
+			fields: fields{
+				attempts:    0,
+				next:        defaultMaximum + time.Second,
+				MaxAttempts: 0,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMaximum,
+				next:     defaultMaximum,
+				attempts: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is zero, next is equal to Max, and attempts is equal to math.MaxUint64, then the Max and no error is returned",
+			fields: fields{
+				attempts:    math.MaxUint64,
+				next:        defaultMaximum,
+				MaxAttempts: 0,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMaximum,
+				next:     defaultMaximum,
+				attempts: math.MaxUint64,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is zero, next is greater than Max, and attempts is equal to math.MaxUint64, then the Max and no error is returned",
+			fields: fields{
+				attempts:    math.MaxUint64,
+				next:        defaultMaximum + time.Second,
+				MaxAttempts: 0,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMaximum,
+				next:     defaultMaximum,
+				attempts: math.MaxUint64,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is non-zero, next is less than Max, and attempts is less than math.MaxUint64 and MaxAttempts, then a positive time.Duration and no error is returned",
+			fields: fields{
+				attempts:    0,
+				next:        0,
+				MaxAttempts: 3,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMinimum,
+				next:     defaultMinimum,
+				attempts: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is non-zero, next is equal to Max, and attempts is less than math.MaxUint64 and MaxAttempts, then Max and no error is returned",
+			fields: fields{
+				attempts:    0,
+				next:        defaultMaximum,
+				MaxAttempts: 3,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMaximum,
+				next:     defaultMaximum,
+				attempts: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is non-zero, next is greater than Max, and attempts is less than math.MaxUint64 and MaxAttempts, then Max and no error is returned",
+			fields: fields{
+				attempts:    0,
+				next:        defaultMaximum + time.Second,
+				MaxAttempts: 3,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   defaultMaximum,
+				next:     defaultMaximum,
+				attempts: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ensure that if MaxAttempts is a non-zero value, and attempts are greater than or equal to that value, an error is returned",
+			fields: fields{
+				attempts:    3,
+				next:        0,
+				MaxAttempts: 3,
+				Factor:      defaultFactor,
+				Min:         defaultMinimum,
+				Max:         defaultMaximum,
+			},
+			want: want{
+				result:   0,
+				next:     0,
+				attempts: 3,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &SimpleBackoff{
+				attempts:    tt.fields.attempts,
+				next:        tt.fields.next,
+				MaxAttempts: tt.fields.MaxAttempts,
+				Factor:      tt.fields.Factor,
+				Min:         tt.fields.Min,
+				Max:         tt.fields.Max,
+			}
+			got, err := b.NextAttempt()
+
+			assert.Equal(t, tt.want.attempts, b.attempts)
+			assert.Equal(t, tt.want.next, b.next)
+			assert.Equal(t, tt.want.result, got)
+
+			switch tt.wantErr {
+			case true:
+				assert.NotNil(t, err)
+			default:
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestJitterBackoff_NextAttempt(t *testing.T) {
+	type fields struct {
+		SimpleBackoff SimpleBackoff
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name: "ensure that if SimpleBackoff.NextAttempt returns a valid value, that a time.Duration with jitter and no error are returned",
+			fields: fields{
+				SimpleBackoff: SimpleBackoff{
+					attempts:    1,
+					next:        0,
+					MaxAttempts: 3,
+					Factor:      defaultFactor,
+					Min:         defaultMinimum,
+					Max:         defaultMaximum,
+				},
+			},
+			want:    defaultMinimum,
+			wantErr: false,
+		},
+		{
+			name: "ensure that if SimpleBackoff.NextAttempt returns an error, that a zero time.Duration and error is returned",
+			fields: fields{
+				SimpleBackoff: SimpleBackoff{
+					attempts:    3,
+					next:        0,
+					MaxAttempts: 3,
+					Factor:      defaultFactor,
+					Min:         defaultMinimum,
+					Max:         defaultMaximum,
+				},
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &JitterBackoff{
+				SimpleBackoff: tt.fields.SimpleBackoff,
+			}
+			got, err := b.NextAttempt()
+
+			switch tt.wantErr {
+			case true:
+				assert.Zero(t, got)
+				assert.NotNil(t, err)
+			default:
+				between(t, got, time.Duration(tt.fields.SimpleBackoff.attempts+1)*tt.fields.SimpleBackoff.Min, tt.fields.SimpleBackoff.Min)
+				assert.Nil(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
I know this repo hasn't changed in the past 6 years, but just putting this out there for posterity's sake

List of changes with some minor details around the reason for them:
* Changed attempts to not be exported as `Reset()` seems to be the intended modifier for that within the `Backoff` interface
* Guarded against unnecessary usage of `math.Pow` as if `MaxAttempts` is not set, this could cause increasing CPU intensive calls that are unnecessary. This is done by maintaining state of the last value this was set to.
* Guarded against overflow of attempts, again if `MaxAttempts` is not set, `attempts` could overflow causing weird behavior as the backoff would essentially reset.
* `JitterBackoff` uses an embedded struct to extend behavior of the `SimpleBackoff`
* `After` ensures that channels are closed when done with them (was unsure if the channel is GC'd without that closure).
* Removed fragile `assert.WithinDuration`s for `After`/`Wait` tests as they depend on the goroutine scheduler and code to be executed without any delays making it fragile and failing depending on the environment.
* Uplifted the tests to be table driven which is a bit more common in golang